### PR TITLE
Updated gulpfile to prevent svgmin from stripping IDs from our SVGs.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,8 +67,9 @@ gulp.task('build_maps', tasks.build_maps = function() {
     gulp.src(MAPS_BLOB)
         .pipe(svgmin({
             plugins: [{
-                mergePaths: false,
                 cleanupIDs: false
+            }, {
+                mergePaths: false
             }]
         }))
         .pipe(gulp.dest('build/static/maps/'));


### PR DESCRIPTION
Fixes issue #13.